### PR TITLE
Fix: Remove subscription placement conflict

### DIFF
--- a/platform-landing-zone.auto.tfvars
+++ b/platform-landing-zone.auto.tfvars
@@ -181,24 +181,24 @@ management_group_settings = {
     private_dns_zone_region                     = "$${starter_location_01}"
     private_dns_zone_resource_group_name        = "$${dns_resource_group_name}"
   }
-  subscription_placement = {
-    identity = {
-      subscription_id       = "$${subscription_id_identity}"
-      management_group_name = "identity"
-    }
-    connectivity = {
-      subscription_id       = "$${subscription_id_connectivity}"
-      management_group_name = "connectivity"
-    }
-    management = {
-      subscription_id       = "$${subscription_id_management}"
-      management_group_name = "management"
-    }
-    security = {
-      subscription_id       = "$${subscription_id_security}"
-      management_group_name = "security"
-    }
-  }
+  #   subscription_placement = {
+  #     identity = {
+  #       subscription_id       = "$${subscription_id_identity}"
+  #       management_group_name = "identity"
+  #     }
+  #     connectivity = {
+  #       subscription_id       = "$${subscription_id_connectivity}"
+  #       management_group_name = "connectivity"
+  #     }
+  #     management = {
+  #       subscription_id       = "$${subscription_id_management}"
+  #       management_group_name = "management"
+  #     }
+  #     security = {
+  #       subscription_id       = "$${subscription_id_security}"
+  #       management_group_name = "security"
+  #     }
+  #   }
   policy_assignments_to_modify = {
     alz = {
       policy_assignments = {


### PR DESCRIPTION
## Problem
The deployment failed because we're trying to place the same subscription in multiple management groups (security, identity, connectivity, management).

## Solution
Commented out the `subscription_placement` configuration since we only have one Azure subscription. The subscription will remain at the tenant root level but will still inherit policies from the management group hierarchy.

## Impact
- Subscription won't be moved into specific management groups
- All policies will still apply via inheritance
- Deployment should now succeed

Fixes the 409 Conflict errors from the previous deployment.