### PR TITLE
💰 Disable expensive resources to reduce monthly costs

### DIFF
--- a/platform-landing-zone.auto.tfvars
+++ b/platform-landing-zone.auto.tfvars
@@ -45,18 +45,18 @@ custom_replacements = {
     dcr_vm_insights_name                    = "dcr-vm-insights"
 
     # Resource provisioning global connectivity
-    ddos_protection_plan_enabled = true
+    ddos_protection_plan_enabled = false
 
     # Resource provisioning primary connectivity
-    primary_firewall_enabled                                             = true
+    primary_firewall_enabled                                             = false
     primary_firewall_management_ip_enabled                               = true
-    primary_virtual_network_gateway_express_route_enabled                = true
+    primary_virtual_network_gateway_express_route_enabled                = false
     primary_virtual_network_gateway_express_route_hobo_public_ip_enabled = true
-    primary_virtual_network_gateway_vpn_enabled                          = true
+    primary_virtual_network_gateway_vpn_enabled                          = false
     primary_private_dns_zones_enabled                                    = true
     primary_private_dns_auto_registration_zone_enabled                   = true
-    primary_private_dns_resolver_enabled                                 = true
-    primary_bastion_enabled                                              = true
+    primary_private_dns_resolver_enabled                                 = false
+    primary_bastion_enabled                                              = false
 
     # Resource names primary connectivity
     primary_virtual_network_name                                 = "vnet-hub-$${starter_location_01}"


### PR DESCRIPTION
## Problem
The current Azure Landing Zone deployment includes expensive enterprise resources that are not needed for development/testing:

- DDoS Protection Plan: **~$3,000/month**
- Azure Firewall: **~$1,250/month**
- ExpressRoute Gateway: **~$730/month**
- VPN Gateway: **~$140/month**
- Azure Bastion: **~$140/month**
- Private DNS Resolver: **~$80/month**

**Total: ~$5,340/month** 💸

## Solution
This PR disables all expensive networking resources by setting their `enabled` flags to `false` in the Terraform configuration.

## What Will Happen
When this is merged and deployed:
- ✅ Terraform will **destroy** these expensive resources
- ✅ Management groups, policies, and DNS zones remain (free/low cost)
- ✅ Hub VNet structure remains (free)
- ✅ Log Analytics workspace remains (minimal cost)

## Cost After This Change
**New estimated cost: ~$50-100/month** ��

Breakdown:
- Private DNS Zones: ~$40/month
- Log Analytics: ~$10-50/month (pay per GB)
- Storage accounts: ~$5/month
- **Total: ~$55-95/month**

## Re-enabling in Future
These resources can be re-enabled by changing the flags back to `true` when needed for production deployment.

## Impact
- ❌ No VPN connectivity (can use Point-to-Site VPN if needed)
- ❌ No Azure Firewall (can use NSGs for basic security)
- ❌ No Bastion (can use Azure CLI `az ssh` or Just-in-Time VM access)
- ✅ All governance and management features remain intact